### PR TITLE
Use promises to track errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1107,6 +1107,7 @@ LIB_OBJS += preload-index.o
 LIB_OBJS += pretty.o
 LIB_OBJS += prio-queue.o
 LIB_OBJS += progress.o
+LIB_OBJS += promise.o
 LIB_OBJS += promisor-remote.o
 LIB_OBJS += prompt.o
 LIB_OBJS += protocol.o

--- a/apply.c
+++ b/apply.c
@@ -3514,8 +3514,7 @@ static void resolve_to(struct image *image, const struct object_id *result_id, s
 					   &size);
 	if (!image->buf || type != OBJ_BLOB) {
 		// TODO this message does not live long enough
-		promise_reject(promise, APPLY_ERR_FATAL, "unable to read blob object %s", oid_to_hex(result_id));
-		return;
+		PROMISE_THROW(promise, APPLY_ERR_FATAL, "unable to read blob object %s", oid_to_hex(result_id));
 	}
 	image->len = size;
 
@@ -3545,8 +3544,7 @@ static void three_way_merge(struct apply_state *state,
 		return;
 	}
 
-		promise_reject(promise, APPLY_ERR_GENERIC, "ll_merge failed");
-		return;
+		PROMISE_THROW(promise, APPLY_ERR_GENERIC, "ll_merge failed");
 
 	read_mmblob(&base_file, base);
 	read_mmblob(&our_file, ours);
@@ -3565,8 +3563,7 @@ static void three_way_merge(struct apply_state *state,
 	free(their_file.ptr);
 	if (status < 0 || !result.ptr) {
 		free(result.ptr);
-		promise_reject(promise, APPLY_ERR_GENERIC, "ll_merge failed");
-		return;
+		PROMISE_THROW(promise, APPLY_ERR_GENERIC, "ll_merge failed");
 	}
 	clear_image(image);
 	image->buf = result.ptr;
@@ -3632,29 +3629,21 @@ static void try_threeway(struct apply_state *state,
 	char *img;
 	struct image tmp_image;
 
-	fprintf(stderr, "check 1\n");
-
 	/* No point falling back to 3-way merge in these cases */
 	if (patch->is_delete ||
 	    S_ISGITLINK(patch->old_mode) || S_ISGITLINK(patch->new_mode) ||
 	    (patch->is_new && !patch->direct_to_threeway) ||
 	    (patch->is_rename && !patch->lines_added && !patch->lines_deleted)) {
-		promise_reject(promise, APPLY_ERR_GENERIC, "");
-		return;
+		PROMISE_THROW(promise, APPLY_ERR_GENERIC, "");
 	}
-
-	fprintf(stderr, "check 2\n");
 
 	/* Preimage the patch was prepared for */
 	if (patch->is_new)
 		write_object_file("", 0, OBJ_BLOB, &pre_oid);
 	else if (repo_get_oid(the_repository, patch->old_oid_prefix, &pre_oid) ||
 		 read_blob_object(&buf, &pre_oid, patch->old_mode)) {
-		promise_reject(promise, APPLY_ERR_GENERIC, _("repository lacks the necessary blob to perform 3-way merge."));
-		return;
+		PROMISE_THROW(promise, APPLY_ERR_GENERIC, _("repository lacks the necessary blob to perform 3-way merge."));
 	}
-
-	fprintf(stderr, "about to perform?\n");
 
 	if (state->apply_verbosity > verbosity_silent && patch->direct_to_threeway)
 		fprintf(stderr, _("Performing three-way merge...\n"));
@@ -3664,8 +3653,7 @@ static void try_threeway(struct apply_state *state,
 	/* Apply the patch to get the post image */
 	if (apply_fragments(state, &tmp_image, patch) < 0) {
 		clear_image(&tmp_image);
-		promise_reject(promise, APPLY_ERR_GENERIC, "");
-		return;
+		PROMISE_THROW(promise, APPLY_ERR_GENERIC, "");
 	}
 	/* post_oid is theirs */
 	write_object_file(tmp_image.buf, tmp_image.len, OBJ_BLOB, &post_oid);
@@ -3674,15 +3662,14 @@ static void try_threeway(struct apply_state *state,
 	/* our_oid is ours */
 	if (patch->is_new) {
 		if (load_current(state, &tmp_image, patch)) {
-			// TODO make sure to error these values
-			promise_reject(promise, APPLY_ERR_GENERIC, _("cannot read the current contents of '%s'"), patch->new_name);
-			return;
+			// Reviewers: This functionality changed. The message would previously print regardless of the verbosity
+			// setting.
+			PROMISE_THROW(promise, APPLY_ERR_GENERIC, _("cannot read the current contents of '%s'"), patch->new_name);
 		}
 	} else {
 		if (load_preimage(state, &tmp_image, patch, st, ce)) {
-			promise_reject(promise, APPLY_ERR_GENERIC, _("cannot read the current contents of '%s'"),
+			PROMISE_THROW(promise, APPLY_ERR_GENERIC, _("cannot read the current contents of '%s'"),
 				     patch->old_name);
-			return;
 		}
 	}
 	write_object_file(tmp_image.buf, tmp_image.len, OBJ_BLOB, &our_oid);
@@ -3690,21 +3677,16 @@ static void try_threeway(struct apply_state *state,
 
 	/* in-core three-way merge between post and our using pre as base */
 	struct promise_t *three_way_merge_promise = promise_init();
-	fprintf(stderr, "ok I got to three_way_merge\n");
 	three_way_merge(state, image, patch->new_name,
 				 &pre_oid, &our_oid, &post_oid, three_way_merge_promise);
 
 	if (three_way_merge_promise->state == PROMISE_FAILURE) {
 		struct failure_result_t result = three_way_merge_promise->result.failure_result;
-
 		assert(result.status < 0);
-		if (state->apply_verbosity > verbosity_silent) {
-			fprintf(stderr, _("Failed to perform three-way merge...\n"));
-		}
 
 		USING_PROMISE_ERROR_START(three_way_merge_promise, error);
 			// Forward on the error message from the three_way_merge promise to the outer promise
-			promise_reject(promise, result.status, error);
+			promise_reject(promise, result.status, "%s", error);
 		USING_PROMISE_ERROR_END(three_way_merge_promise, error);
 
 		return;
@@ -3764,9 +3746,16 @@ static int apply_data(struct apply_state *state, struct patch *patch,
 				// -10 indicates fatal error. Die early.
 				DIE_WITH_PROMISE(merge_promise);
 			} else {
-				USING_PROMISE_ERROR_START(merge_promise, error_message);
-				fprintf(stderr, "Failed to apply patch!\n	%s\n", error_message);
-				USING_PROMISE_ERROR_END(merge_promise, error_message);
+				if (state->apply_verbosity == verbosity_verbose) {
+					USING_PROMISE_ERROR_START(merge_promise, error_message);
+					fprintf(stderr, _("Failed to perform three-way merge...\n"));
+					if (strlen(error_message) > 0) {
+						fprintf(stderr, "\t%s\n", error_message);
+					}
+					USING_PROMISE_ERROR_END(merge_promise, error_message);
+				} else if (state->apply_verbosity > verbosity_silent) {
+					fprintf(stderr, _("Failed to perform three-way merge...\n"));
+				}
 			}
 			maybe_error_early = 1;
 		}

--- a/apply.c
+++ b/apply.c
@@ -3699,9 +3699,14 @@ static void try_threeway(struct apply_state *state,
 		if (state->apply_verbosity > verbosity_silent) {
 			fprintf(stderr, _("Failed to perform three-way merge...\n"));
 		}
+
+
+		char *three_way_error;
+		promise_copy_error(three_way_merge_promise, &three_way_error, NULL);
 		// Forward on the error message from the three_way_merge promise to the outer promise
 		promise_reject(promise, three_way_merge_promise->result.failure_result.status,
-		       three_way_merge_promise->result.failure_result.message);
+		       three_way_error);
+		free(three_way_error);
 		return;
 	}
 
@@ -3756,9 +3761,14 @@ static int apply_data(struct apply_state *state, struct patch *patch,
 
 			if (merge_promise->result.failure_result.status == APPLY_ERR_FATAL) {
 				// -10 indicates fatal error. Die early.
-				die("%s", merge_promise->result.failure_result.message);
+				char *message;
+				promise_copy_error(merge_promise, &message, NULL);
+				die("%s", message);
 			} else {
-				fprintf(stderr, "Failed to apply patch:\n%s\n", merge_promise->result.failure_result.message);
+				char* error_message;
+				promise_copy_error(merge_promise, &error_message, NULL);
+				fprintf(stderr, "Failed to apply patch!!!:\n%s\n", error_message);
+				free(error_message);
 			}
 			maybe_error_early = 1;
 		}

--- a/apply.c
+++ b/apply.c
@@ -3626,7 +3626,6 @@ static void try_threeway(struct apply_state *state,
 	struct object_id pre_oid, post_oid, our_oid;
 	struct strbuf buf = STRBUF_INIT;
 	size_t len;
-	int status;
 	char *img;
 	struct image tmp_image;
 
@@ -3696,7 +3695,7 @@ static void try_threeway(struct apply_state *state,
 		return;
 	}
 
-	if (status) {
+	if (three_way_merge_promise->result.success_result) {
 		patch->conflicted_threeway = 1;
 		if (patch->is_new)
 			oidclr(&patch->threeway_stage[0]);
@@ -3737,7 +3736,7 @@ static int apply_data(struct apply_state *state, struct patch *patch,
 
 			if (merge_promise->result.failure_result.status == APPLY_ERR_FATAL) {
 				// -10 indicates fatal error. Die early.
-				die(merge_promise->result.failure_result.message);
+				die("%s", merge_promise->result.failure_result.message);
 			}
 			maybe_error_early = 1;
 		}
@@ -3751,7 +3750,6 @@ static int apply_data(struct apply_state *state, struct patch *patch,
 		/* Note: with --reject, apply_fragments() returns 0 */
 		if (patch->direct_to_threeway || apply_fragments(state, &image, patch) < 0)
 			return APPLY_ERR_GENERIC;
-		}
 	}
 
 	patch->result = image.buf;

--- a/apply.c
+++ b/apply.c
@@ -3544,8 +3544,6 @@ static void three_way_merge(struct apply_state *state,
 		return;
 	}
 
-		PROMISE_THROW(promise, APPLY_ERR_GENERIC, "ll_merge failed");
-
 	read_mmblob(&base_file, base);
 	read_mmblob(&our_file, ours);
 	read_mmblob(&their_file, theirs);
@@ -3727,16 +3725,6 @@ static int apply_data(struct apply_state *state, struct patch *patch,
 		struct promise_t *merge_promise = promise_init();
 		try_threeway(state, &image, patch, st, ce, merge_promise);
 		promise_assert_finished(merge_promise);
-
-		// IF_PROMISE_FAILED(merge_promise, {
-		// 	if (status == APPLY_ERR_FATAL) {
-		// 		// -10 indicates fatal error. Die early.
-		// 		die("%s", message);
-		// 	} else {
-		// 		fprintf(stderr, "Failed to apply patch:\n%s\n", merge_promise->result.failure_result.message);
-		// 	}
-		// 	maybe_error_early = 1;	
-		// })
 
 		if (merge_promise->state == PROMISE_FAILURE) {
 			struct failure_result_t result = merge_promise->result.failure_result;

--- a/apply.c
+++ b/apply.c
@@ -3761,14 +3761,11 @@ static int apply_data(struct apply_state *state, struct patch *patch,
 
 			if (merge_promise->result.failure_result.status == APPLY_ERR_FATAL) {
 				// -10 indicates fatal error. Die early.
-				char *message;
-				promise_copy_error(merge_promise, &message, NULL);
-				die("%s", message);
+				DIE_WITH_PROMISE(merge_promise);
 			} else {
-				char* error_message;
-				promise_copy_error(merge_promise, &error_message, NULL);
-				fprintf(stderr, "Failed to apply patch!!!:\n%s\n", error_message);
-				free(error_message);
+				USING_PROMISE_ERROR_START(error_message);
+				fprintf(stderr, "Failed to apply patch!\n	%s\n", error_message);
+				USING_PROMISE_ERROR_END(error_message);
 			}
 			maybe_error_early = 1;
 		}

--- a/apply.c
+++ b/apply.c
@@ -3695,16 +3695,17 @@ static void try_threeway(struct apply_state *state,
 				 &pre_oid, &our_oid, &post_oid, three_way_merge_promise);
 
 	if (three_way_merge_promise->state == PROMISE_FAILURE) {
-		assert(three_way_merge_promise->result.failure_result.status < 0);
+		struct failure_result_t result = three_way_merge_promise->result.failure_result;
+
+		assert(result.status < 0);
 		if (state->apply_verbosity > verbosity_silent) {
 			fprintf(stderr, _("Failed to perform three-way merge...\n"));
 		}
 
-
 		char *three_way_error;
 		promise_copy_error(three_way_merge_promise, &three_way_error, NULL);
 		// Forward on the error message from the three_way_merge promise to the outer promise
-		promise_reject(promise, three_way_merge_promise->result.failure_result.status,
+		promise_reject(promise, result.status,
 		       three_way_error);
 		free(three_way_error);
 		return;
@@ -3757,9 +3758,10 @@ static int apply_data(struct apply_state *state, struct patch *patch,
 		// })
 
 		if (merge_promise->state == PROMISE_FAILURE) {
-			assert(merge_promise->result.failure_result.status < 0);	
+			struct failure_result_t result = merge_promise->result.failure_result;
+			assert(result.status < 0);	
 
-			if (merge_promise->result.failure_result.status == APPLY_ERR_FATAL) {
+			if (result.status == APPLY_ERR_FATAL) {
 				// -10 indicates fatal error. Die early.
 				DIE_WITH_PROMISE(merge_promise);
 			} else {

--- a/apply.c
+++ b/apply.c
@@ -27,6 +27,7 @@
 #include "object-file.h"
 #include "parse-options.h"
 #include "path.h"
+#include "promise.h"
 #include "quote.h"
 #include "read-cache.h"
 #include "rerere.h"
@@ -36,7 +37,6 @@
 #include "symlinks.h"
 #include "wildmatch.h"
 #include "ws.h"
-#include "promise.h"
 
 struct gitdiff_data {
 	struct strbuf *root;

--- a/apply.c
+++ b/apply.c
@@ -3702,12 +3702,11 @@ static void try_threeway(struct apply_state *state,
 			fprintf(stderr, _("Failed to perform three-way merge...\n"));
 		}
 
-		char *three_way_error;
-		promise_copy_error(three_way_merge_promise, &three_way_error, NULL);
-		// Forward on the error message from the three_way_merge promise to the outer promise
-		promise_reject(promise, result.status,
-		       three_way_error);
-		free(three_way_error);
+		USING_PROMISE_ERROR_START(three_way_merge_promise, error);
+			// Forward on the error message from the three_way_merge promise to the outer promise
+			promise_reject(promise, result.status, error);
+		USING_PROMISE_ERROR_END(three_way_merge_promise, error);
+
 		return;
 	}
 
@@ -3765,9 +3764,9 @@ static int apply_data(struct apply_state *state, struct patch *patch,
 				// -10 indicates fatal error. Die early.
 				DIE_WITH_PROMISE(merge_promise);
 			} else {
-				USING_PROMISE_ERROR_START(error_message);
+				USING_PROMISE_ERROR_START(merge_promise, error_message);
 				fprintf(stderr, "Failed to apply patch!\n	%s\n", error_message);
-				USING_PROMISE_ERROR_END(error_message);
+				USING_PROMISE_ERROR_END(merge_promise, error_message);
 			}
 			maybe_error_early = 1;
 		}

--- a/apply.c
+++ b/apply.c
@@ -36,6 +36,7 @@
 #include "symlinks.h"
 #include "wildmatch.h"
 #include "ws.h"
+#include "promise.h"
 
 struct gitdiff_data {
 	struct strbuf *root;
@@ -3502,7 +3503,7 @@ static int load_preimage(struct apply_state *state,
 	return 0;
 }
 
-static int resolve_to(struct image *image, const struct object_id *result_id)
+static void resolve_to(struct promise_t* promise, struct image *image, const struct object_id *result_id)
 {
 	unsigned long size;
 	enum object_type type;
@@ -3511,29 +3512,38 @@ static int resolve_to(struct image *image, const struct object_id *result_id)
 
 	image->buf = repo_read_object_file(the_repository, result_id, &type,
 					   &size);
-	if (!image->buf || type != OBJ_BLOB)
-		die("unable to read blob object %s", oid_to_hex(result_id));
+	if (!image->buf || type != OBJ_BLOB) {
+		// TODO this message does not live long enough
+		promise_reject(promise, APPLY_ERR_FATAL, "unable to read blob object %s", oid_to_hex(result_id));
+		return;
+	}
 	image->len = size;
 
-	return 0;
+	promise_resolve(promise, 0);
 }
 
-static int three_way_merge(struct apply_state *state,
+
+
+static void three_way_merge(struct apply_state *state,
 			   struct image *image,
 			   char *path,
 			   const struct object_id *base,
 			   const struct object_id *ours,
-			   const struct object_id *theirs)
+			   const struct object_id *theirs,
+			   struct promise_t *promise)
 {
 	mmfile_t base_file, our_file, their_file;
 	mmbuffer_t result = { NULL };
 	enum ll_merge_result status;
 
 	/* resolve trivial cases first */
-	if (oideq(base, ours))
-		return resolve_to(image, theirs);
-	else if (oideq(base, theirs) || oideq(ours, theirs))
-		return resolve_to(image, ours);
+	if (oideq(base, ours)) {
+		resolve_to(promise, image, theirs);
+		return;
+	} else if (oideq(base, theirs) || oideq(ours, theirs)) {
+		resolve_to(promise, image, ours);
+		return;
+	}
 
 	read_mmblob(&base_file, base);
 	read_mmblob(&our_file, ours);
@@ -3552,13 +3562,14 @@ static int three_way_merge(struct apply_state *state,
 	free(their_file.ptr);
 	if (status < 0 || !result.ptr) {
 		free(result.ptr);
-		return -1;
+		promise_reject(promise, APPLY_ERR_GENERIC, "ll_merge failed");
+		return;
 	}
 	clear_image(image);
 	image->buf = result.ptr;
 	image->len = result.size;
 
-	return status;
+	promise_resolve(promise, status);
 }
 
 /*
@@ -3605,11 +3616,12 @@ static int load_current(struct apply_state *state,
 	return 0;
 }
 
-static int try_threeway(struct apply_state *state,
+static void try_threeway(struct apply_state *state,
 			struct image *image,
 			struct patch *patch,
 			struct stat *st,
-			const struct cache_entry *ce)
+			const struct cache_entry *ce,
+			struct promise_t *promise)
 {
 	struct object_id pre_oid, post_oid, our_oid;
 	struct strbuf buf = STRBUF_INIT;
@@ -3622,15 +3634,19 @@ static int try_threeway(struct apply_state *state,
 	if (patch->is_delete ||
 	    S_ISGITLINK(patch->old_mode) || S_ISGITLINK(patch->new_mode) ||
 	    (patch->is_new && !patch->direct_to_threeway) ||
-	    (patch->is_rename && !patch->lines_added && !patch->lines_deleted))
-		return -1;
+	    (patch->is_rename && !patch->lines_added && !patch->lines_deleted)) {
+		promise_reject(promise, APPLY_ERR_GENERIC, "");
+		return;
+	}
 
 	/* Preimage the patch was prepared for */
 	if (patch->is_new)
 		write_object_file("", 0, OBJ_BLOB, &pre_oid);
 	else if (repo_get_oid(the_repository, patch->old_oid_prefix, &pre_oid) ||
-		 read_blob_object(&buf, &pre_oid, patch->old_mode))
-		return error(_("repository lacks the necessary blob to perform 3-way merge."));
+		 read_blob_object(&buf, &pre_oid, patch->old_mode)) {
+		promise_reject(promise, APPLY_ERR_GENERIC, _("repository lacks the necessary blob to perform 3-way merge."));
+		return;
+	}
 
 	if (state->apply_verbosity > verbosity_silent && patch->direct_to_threeway)
 		fprintf(stderr, _("Performing three-way merge...\n"));
@@ -3640,7 +3656,8 @@ static int try_threeway(struct apply_state *state,
 	/* Apply the patch to get the post image */
 	if (apply_fragments(state, &tmp_image, patch) < 0) {
 		clear_image(&tmp_image);
-		return -1;
+		promise_reject(promise, APPLY_ERR_GENERIC, "");
+		return;
 	}
 	/* post_oid is theirs */
 	write_object_file(tmp_image.buf, tmp_image.len, OBJ_BLOB, &post_oid);
@@ -3648,25 +3665,35 @@ static int try_threeway(struct apply_state *state,
 
 	/* our_oid is ours */
 	if (patch->is_new) {
-		if (load_current(state, &tmp_image, patch))
-			return error(_("cannot read the current contents of '%s'"),
-				     patch->new_name);
+		if (load_current(state, &tmp_image, patch)) {
+			// TODO make sure to error these values
+			promise_reject(promise, APPLY_ERR_GENERIC, _("cannot read the current contents of '%s'"), patch->new_name);
+			return;
+		}
 	} else {
-		if (load_preimage(state, &tmp_image, patch, st, ce))
-			return error(_("cannot read the current contents of '%s'"),
+		if (load_preimage(state, &tmp_image, patch, st, ce)) {
+			promise_reject(promise, APPLY_ERR_GENERIC, _("cannot read the current contents of '%s'"),
 				     patch->old_name);
+			return;
+		}
 	}
 	write_object_file(tmp_image.buf, tmp_image.len, OBJ_BLOB, &our_oid);
 	clear_image(&tmp_image);
 
 	/* in-core three-way merge between post and our using pre as base */
-	status = three_way_merge(state, image, patch->new_name,
-				 &pre_oid, &our_oid, &post_oid);
-	if (status < 0) {
-		if (state->apply_verbosity > verbosity_silent)
-			fprintf(stderr,
-				_("Failed to perform three-way merge...\n"));
-		return status;
+	struct promise_t *three_way_merge_promise = create_promise();
+	three_way_merge(state, image, patch->new_name,
+				 &pre_oid, &our_oid, &post_oid, three_way_merge_promise);
+
+	if (three_way_merge_promise->state == PROMISE_FAILURE) {
+		assert(three_way_merge_promise->result.failure_result.status < 0);
+		if (state->apply_verbosity > verbosity_silent) {
+			fprintf(stderr, _("Failed to perform three-way merge...\n"));
+		}
+		// Forward on the error message from the three_way_merge promise to the outer promise
+		promise_reject(promise, three_way_merge_promise->result.failure_result.status,
+		       three_way_merge_promise->result.failure_result.message);
+		return;
 	}
 
 	if (status) {
@@ -3687,7 +3714,7 @@ static int try_threeway(struct apply_state *state,
 				_("Applied patch to '%s' cleanly.\n"),
 				patch->new_name);
 	}
-	return 0;
+	promise_resolve(promise, 0);
 }
 
 static int apply_data(struct apply_state *state, struct patch *patch,
@@ -3696,26 +3723,48 @@ static int apply_data(struct apply_state *state, struct patch *patch,
 	struct image image;
 
 	if (load_preimage(state, &image, patch, st, ce) < 0)
-		return -1;
+		return APPLY_ERR_GENERIC;
 
-	if (!state->threeway || try_threeway(state, &image, patch, st, ce) < 0) {
+	int maybe_error_early = !state->threeway;
+
+	if (!maybe_error_early) {
+		struct promise_t *merge_promise = create_promise();
+		try_threeway(state, &image, patch, st, ce, merge_promise);
+		promise_assert_finished(merge_promise);
+
+		if (merge_promise->state == PROMISE_FAILURE) {
+			assert(merge_promise->result.failure_result.status < 0);	
+
+			if (merge_promise->result.failure_result.status == APPLY_ERR_FATAL) {
+				// -10 indicates fatal error. Die early.
+				die(merge_promise->result.failure_result.message);
+			}
+			maybe_error_early = 1;
+		}
+	}
+
+	if (maybe_error_early) {
 		if (state->apply_verbosity > verbosity_silent &&
 		    state->threeway && !patch->direct_to_threeway)
 			fprintf(stderr, _("Falling back to direct application...\n"));
 
 		/* Note: with --reject, apply_fragments() returns 0 */
 		if (patch->direct_to_threeway || apply_fragments(state, &image, patch) < 0)
-			return -1;
+			return APPLY_ERR_GENERIC;
+		}
 	}
+
 	patch->result = image.buf;
 	patch->resultsize = image.len;
 	add_to_fn_table(state, patch);
 	free(image.line_allocated);
 
-	if (0 < patch->is_delete && patch->resultsize)
-		return error(_("removal patch leaves file contents"));
+	if (0 < patch->is_delete && patch->resultsize) {
+		error(_("removal patch leaves file contents"));
+		return APPLY_ERR_GENERIC;
+	}
 
-	return 0;
+	return APPLY_SUCCESS;
 }
 
 /*

--- a/apply.c
+++ b/apply.c
@@ -3503,7 +3503,7 @@ static int load_preimage(struct apply_state *state,
 	return 0;
 }
 
-static void resolve_to(struct promise_t* promise, struct image *image, const struct object_id *result_id)
+static void resolve_to(struct image *image, const struct object_id *result_id, struct promise_t* promise)
 {
 	unsigned long size;
 	enum object_type type;
@@ -3538,10 +3538,10 @@ static void three_way_merge(struct apply_state *state,
 
 	/* resolve trivial cases first */
 	if (oideq(base, ours)) {
-		resolve_to(promise, image, theirs);
+		resolve_to(image, theirs, promise);
 		return;
 	} else if (oideq(base, theirs) || oideq(ours, theirs)) {
-		resolve_to(promise, image, ours);
+		resolve_to(image, ours, promise);
 		return;
 	}
 

--- a/apply.c
+++ b/apply.c
@@ -3513,7 +3513,6 @@ static void resolve_to(struct image *image, const struct object_id *result_id, s
 	image->buf = repo_read_object_file(the_repository, result_id, &type,
 					   &size);
 	if (!image->buf || type != OBJ_BLOB) {
-		// TODO this message does not live long enough
 		PROMISE_THROW(promise, APPLY_ERR_FATAL, "unable to read blob object %s", oid_to_hex(result_id));
 	}
 	image->len = size;
@@ -3728,7 +3727,7 @@ static int apply_data(struct apply_state *state, struct patch *patch,
 
 		if (merge_promise->state == PROMISE_FAILURE) {
 			struct failure_result_t result = merge_promise->result.failure_result;
-			assert(result.status < 0);	
+			assert(result.status < 0);
 
 			if (result.status == APPLY_ERR_FATAL) {
 				// -10 indicates fatal error. Die early.

--- a/apply.c
+++ b/apply.c
@@ -3639,7 +3639,7 @@ static void try_threeway(struct apply_state *state,
 	if (patch->is_new)
 		write_object_file("", 0, OBJ_BLOB, &pre_oid);
 	else if (repo_get_oid(the_repository, patch->old_oid_prefix, &pre_oid) ||
-		 read_blob_object(&buf, &pre_oid, patch->old_mode)) {
+		read_blob_object(&buf, &pre_oid, patch->old_mode)) {
 		PROMISE_THROW(promise, APPLY_ERR_GENERIC, _("repository lacks the necessary blob to perform 3-way merge."));
 	}
 

--- a/apply.c
+++ b/apply.c
@@ -3689,7 +3689,7 @@ static void try_threeway(struct apply_state *state,
 	clear_image(&tmp_image);
 
 	/* in-core three-way merge between post and our using pre as base */
-	struct promise_t *three_way_merge_promise = create_promise();
+	struct promise_t *three_way_merge_promise = promise_init();
 	fprintf(stderr, "ok I got to three_way_merge\n");
 	three_way_merge(state, image, patch->new_name,
 				 &pre_oid, &our_oid, &post_oid, three_way_merge_promise);
@@ -3737,7 +3737,7 @@ static int apply_data(struct apply_state *state, struct patch *patch,
 	int maybe_error_early = !state->threeway;
 
 	if (!maybe_error_early) {
-		struct promise_t *merge_promise = create_promise();
+		struct promise_t *merge_promise = promise_init();
 		try_threeway(state, &image, patch, st, ce, merge_promise);
 		promise_assert_finished(merge_promise);
 

--- a/apply.h
+++ b/apply.h
@@ -8,7 +8,7 @@
 
 #define APPLY_SUCCESS 0
 
-/* Error codes (must less than 0) */
+/* Error codes (must be less than 0) */
 #define APPLY_ERR_GENERIC -1
 #define APPLY_ERR_FATAL -10
 

--- a/apply.h
+++ b/apply.h
@@ -6,6 +6,12 @@
 #include "string-list.h"
 #include "strmap.h"
 
+#define APPLY_SUCCESS 0
+
+/* Error codes (must less than 0) */
+#define APPLY_ERR_GENERIC -1
+#define APPLY_ERR_FATAL -10
+
 struct repository;
 
 enum apply_ws_error_action {

--- a/promise.c
+++ b/promise.c
@@ -5,13 +5,13 @@
 
 void promise_assert_finished(struct promise_t *p) {
     if (p->state == PROMISE_UNRESOLVED) {
-        BUG("expected promise to have resolved");
+        BUG("expected promise to have been resolved/rejected");
     }
 }
 
 void promise_resolve(struct promise_t *p, int status) {
     if (p->state != PROMISE_UNRESOLVED) {
-        BUG("promise was already resolved");
+        BUG("promise was already resolved/rejected");
         return;
     }
     p->result.success_result = status;
@@ -20,35 +20,53 @@ void promise_resolve(struct promise_t *p, int status) {
 
 void promise_reject(struct promise_t *p, int status, const char* fmt, ...) {
     if (p->state != PROMISE_UNRESOLVED) {
-        BUG("promise was already resolved");
+        BUG("promise was already resolved/rejected");
         return;
     }
     p->result.failure_result.status = status;
 
+    strbuf_init(failure_result.message, 0);
+
     va_list args;
     va_start(args, fmt);
-    xsnprintf(p->result.failure_result.message, PROMISE_MESSAGE_LEN, fmt, args);
+    strbuf_addf(p->result.failure_result.message, fmt, args);
     va_end(args);
 
     p->state = PROMISE_FAILURE;
 }
 
-struct promise_t *create_promise() {
-	// static int promise_id = 0; /* GLOBAL */
-
+struct promise_t *promise_init() {
 	struct promise_t *new_promise = xmalloc(sizeof(struct promise_t));
     new_promise->state = PROMISE_UNRESOLVED;
 
-    struct failure_result_t failure_result = {
-        .status = 0,
-        .message = { 0 }
-    };
+    struct failure_result_t failure_result;
+    failure_result.status = 0;
 
     new_promise->result.failure_result = failure_result;
 
     return new_promise;
 }
 
-void release_promise(struct promise_t *promise) {
+/**
+ * Performs a partial release of the promise, but if this function returns
+ * a nonnegative value, an additional free() must be called on the error_message
+ * buffer.
+ */
+int promise_consume(struct promise_t *promise, char **error_message) {
+    int size = -1;
+    if (promise->state == PROMISE_FAILURE) {
+        *error_message = strbuf_detach(promise->result.failure_result.message, &size);
+    }
     free(promise);
+    return size;
+}
+
+/**
+ * Fully deallocates the promise as well as the error message, if any.
+ */
+void promise_release(struct promise_t *promise) {
+    char *error_message;
+    if (promise_consume(promise, &error_message) >= 0) {
+        free(error_message);
+    }
 }

--- a/promise.c
+++ b/promise.c
@@ -4,55 +4,55 @@
 #include "promise.h"
 
 void promise_assert_finished(struct promise_t *p) {
-    if (p->state == PROMISE_UNRESOLVED) {
-        BUG("expected promise to have been resolved/rejected");
-    }
+	if (p->state == PROMISE_UNRESOLVED) {
+		BUG("expected promise to have been resolved/rejected");
+	}
 }
 
 void promise_assert_failure(struct promise_t *p) {
-    if (p->state != PROMISE_FAILURE) {
-        BUG("expected promise to have been rejected");
-    }
+	if (p->state != PROMISE_FAILURE) {
+		BUG("expected promise to have been rejected");
+	}
 }
 
 void promise_resolve(struct promise_t *p, int status) {
-    if (p->state != PROMISE_UNRESOLVED) {
-        BUG("promise was already resolved/rejected");
-        return;
-    }
-    p->result.success_result = status;
-    p->state = PROMISE_SUCCESS;
+	if (p->state != PROMISE_UNRESOLVED) {
+		BUG("promise was already resolved/rejected");
+		return;
+	}
+	p->result.success_result = status;
+	p->state = PROMISE_SUCCESS;
 }
 
 void promise_reject(struct promise_t *p, int status, const char* fmt, ...) {
-    if (p->state != PROMISE_UNRESOLVED) {
-        BUG("promise was already resolved/rejected");
-        return;
-    }
-    p->result.failure_result.status = status;
+	if (p->state != PROMISE_UNRESOLVED) {
+		BUG("promise was already resolved/rejected");
+		return;
+	}
+	p->result.failure_result.status = status;
 
-    strbuf_init(&p->result.failure_result.message, 0);
+	strbuf_init(&p->result.failure_result.message, 0);
 
-    va_list args;
-    va_start(args, fmt);
-    strbuf_addf(&p->result.failure_result.message, fmt, args);
-    va_end(args);
+	va_list args;
+	va_start(args, fmt);
+	strbuf_addf(&p->result.failure_result.message, fmt, args);
+	va_end(args);
 
-    p->state = PROMISE_FAILURE;
+	p->state = PROMISE_FAILURE;
 }
 
 struct promise_t *promise_init() {
-    // Promises are allocated on the heap, because they represent potentially long-running tasks,
-    // and a stack-allocated value might not live long enough.
+	// Promises are allocated on the heap, because they represent potentially long-running tasks,
+	// and a stack-allocated value might not live long enough.
 	struct promise_t *new_promise = xmalloc(sizeof(struct promise_t));
-    new_promise->state = PROMISE_UNRESOLVED;
+	new_promise->state = PROMISE_UNRESOLVED;
 
-    struct failure_result_t failure_result;
-    failure_result.status = 0;
+	struct failure_result_t failure_result;
+	failure_result.status = 0;
 
-    new_promise->result.failure_result = failure_result;
+	new_promise->result.failure_result = failure_result;
 
-    return new_promise;
+	return new_promise;
 }
 
 /**
@@ -66,25 +66,25 @@ struct promise_t *promise_init() {
  * than the terminated string, and its actual size is indicated by *size.
  */
 void promise_copy_error(struct promise_t *p, char **error_message, size_t *size) {
-    promise_assert_failure(p);
+	promise_assert_failure(p);
 
-    size_t local_size;
-    *error_message = strbuf_detach(&p->result.failure_result.message, &local_size);
-    if (size != NULL) {
-        *size = local_size;
-    }
+	size_t local_size;
+	*error_message = strbuf_detach(&p->result.failure_result.message, &local_size);
+	if (size != NULL) {
+		*size = local_size;
+	}
 
-    // We are only doing a copy, not a consume, so we need to put the error message back
-    // the way we found it.
-    strbuf_add(&p->result.failure_result.message, *error_message, strlen(*error_message));
+	// We are only doing a copy, not a consume, so we need to put the error message back
+	// the way we found it.
+	strbuf_add(&p->result.failure_result.message, *error_message, strlen(*error_message));
 }
 
 /**
  * Fully deallocates the promise as well as the error message, if any.
  */
 void promise_release(struct promise_t *p) {
-    if (p->state == PROMISE_FAILURE) {
-        strbuf_release(&p->result.failure_result.message);
-    }
-    free(p);
+	if (p->state == PROMISE_FAILURE) {
+		strbuf_release(&p->result.failure_result.message);
+	}
+	free(p);
 }

--- a/promise.c
+++ b/promise.c
@@ -1,5 +1,54 @@
 /*
  * Generic implementation of callbacks with await checking.
  */
-#include "git-compat-util.h"
 #include "promise.h"
+
+void promise_assert_finished(struct promise_t *p) {
+    if (p->state == PROMISE_UNRESOLVED) {
+        BUG("expected promise to have resolved");
+    }
+}
+
+void promise_resolve(struct promise_t *p, int status) {
+    if (p->state != PROMISE_UNRESOLVED) {
+        BUG("promise was already resolved");
+        return;
+    }
+    p->result.success_result = status;
+    p->state = PROMISE_SUCCESS;
+}
+
+void promise_reject(struct promise_t *p, int status, const char* fmt, ...) {
+    if (p->state != PROMISE_UNRESOLVED) {
+        BUG("promise was already resolved");
+        return;
+    }
+    p->result.failure_result.status = status;
+
+    va_list args;
+    va_start(args, fmt);
+    xsnprintf(p->result.failure_result.message, PROMISE_MESSAGE_LEN, fmt, args);
+    va_end(args);
+
+    p->state = PROMISE_FAILURE;
+}
+
+struct promise_t *create_promise() {
+	// static int promise_id = 0; /* GLOBAL */
+
+	struct promise_t *new_promise = xmalloc(sizeof(struct promise_t));
+    new_promise->state = PROMISE_UNRESOLVED;
+
+    struct failure_result_t failure_result = {
+        .status = 0,
+        .message = { 0 }
+    };
+
+    new_promise->result.failure_result = failure_result;
+
+    return new_promise;
+}
+
+void release_promise(struct promise_t *promise) {
+    free(promise);
+}

--- a/promise.c
+++ b/promise.c
@@ -42,6 +42,8 @@ void promise_reject(struct promise_t *p, int status, const char* fmt, ...) {
 }
 
 struct promise_t *promise_init() {
+    // Promises are allocated on the heap, because they represent potentially long-running tasks,
+    // and a stack-allocated value might not live long enough.
 	struct promise_t *new_promise = xmalloc(sizeof(struct promise_t));
     new_promise->state = PROMISE_UNRESOLVED;
 

--- a/promise.c
+++ b/promise.c
@@ -1,0 +1,5 @@
+/*
+ * Generic implementation of callbacks with await checking.
+ */
+#include "git-compat-util.h"
+#include "promise.h"

--- a/promise.h
+++ b/promise.h
@@ -15,16 +15,16 @@ typedef int success_result_t;
 #define PROMISE_MESSAGE_LEN 4096
 
 struct failure_result_t {
-    int status;
-    struct strbuf message;
+	int status;
+	struct strbuf message;
 };
 
 struct promise_t {
-    enum promise_state state;
-    union {
-        success_result_t success_result;
-        struct failure_result_t failure_result;
-    } result;
+	enum promise_state state;
+	union {
+		success_result_t success_result;
+		struct failure_result_t failure_result;
+	} result;
 };
 
 // Function to assert that a promise has been resolved
@@ -46,22 +46,22 @@ void promise_copy_error(struct promise_t *promise, char **error_message, size_t 
 void promise_release(struct promise_t *promise);
 
 #define DIE_WITH_PROMISE(p) do { \
-    char *message; \
-    promise_copy_error((p), &message, NULL); \
-    die("%s", message); \
+	char *message; \
+	promise_copy_error((p), &message, NULL); \
+	die("%s", message); \
 } while (0)
 
 #define PROMISE_THROW(p, errcode, ...) do { \
-    promise_reject(p, errcode, __VA_ARGS__); \
-    return; \
+	promise_reject(p, errcode, __VA_ARGS__); \
+	return; \
 } while (0)
 
 #define USING_PROMISE_ERROR_START(p, m) do { \
-    char* (m); \
-    promise_copy_error((p), &(m), NULL);
+	char* (m); \
+	promise_copy_error((p), &(m), NULL);
 
 #define USING_PROMISE_ERROR_END(p, m) \
-    free((m)); \
+	free((m)); \
 } while (0)
 
 #endif

--- a/promise.h
+++ b/promise.h
@@ -45,4 +45,18 @@ void promise_copy_error(struct promise_t *promise, char **error_message, size_t 
 // Fully deallocates the promise
 void promise_release(struct promise_t *promise);
 
+#define DIE_WITH_PROMISE(p) do { \
+    char *message; \
+    promise_copy_error((p), &message, NULL); \
+    die("%s", message); \
+} while (0)
+
+#define USING_PROMISE_ERROR_START(ident) do { \
+    char* ident; \
+    promise_copy_error(merge_promise, &ident, NULL);
+
+#define USING_PROMISE_ERROR_END(ident) \
+    free(ident); \
+} while (0)
+
 #endif

--- a/promise.h
+++ b/promise.h
@@ -51,12 +51,12 @@ void promise_release(struct promise_t *promise);
     die("%s", message); \
 } while (0)
 
-#define USING_PROMISE_ERROR_START(ident) do { \
-    char* ident; \
-    promise_copy_error(merge_promise, &ident, NULL);
+#define USING_PROMISE_ERROR_START(p, m) do { \
+    char* (m); \
+    promise_copy_error((p), &(m), NULL);
 
-#define USING_PROMISE_ERROR_END(ident) \
-    free(ident); \
+#define USING_PROMISE_ERROR_END(p, m) \
+    free((p)); \
 } while (0)
 
 #endif

--- a/promise.h
+++ b/promise.h
@@ -47,7 +47,7 @@ void promise_resolve(struct promise_t *p, int status) {
     p->state = PROMISE_SUCCESS;
 }
 
-void promise_reject(struct promise_t *p, int status, char* fmt, ...) {
+void promise_reject(struct promise_t *p, int status, const char* fmt, ...) {
     if (p->state != PROMISE_UNRESOLVED) {
         BUG("promise was already resolved");
         return;

--- a/promise.h
+++ b/promise.h
@@ -51,12 +51,17 @@ void promise_release(struct promise_t *promise);
     die("%s", message); \
 } while (0)
 
+#define PROMISE_THROW(p, errcode, ...) do { \
+    promise_reject(p, errcode, __VA_ARGS__); \
+    return; \
+} while (0)
+
 #define USING_PROMISE_ERROR_START(p, m) do { \
     char* (m); \
     promise_copy_error((p), &(m), NULL);
 
 #define USING_PROMISE_ERROR_END(p, m) \
-    free((p)); \
+    free((m)); \
 } while (0)
 
 #endif

--- a/promise.h
+++ b/promise.h
@@ -1,17 +1,13 @@
 #ifndef PROMISE_H
 #define PROMISE_H
 
+#include "git-compat-util.h"
+
 enum promise_state {
 	PROMISE_UNRESOLVED = 0,
 	PROMISE_SUCCESS = 1,
 	PROMISE_FAILURE = 2,
 };
-
-// struct PromiseTag {
-//     // int promise_id;
-//     void (*user_success_cbk)(int status, void* data);
-//     void (*user_error_cbk)(int status, char* msg, void* data); 
-// }
 
 typedef int success_result_t;
 
@@ -28,58 +24,21 @@ struct promise_t {
         success_result_t success_result;
         struct failure_result_t failure_result;
     } result;
-    // void (*success_cbk)(int status, void* data);
-    // void (*error_cbk)(int status, char* msg, void* data);
 };
 
-void promise_assert_finished(struct promise_t *p) {
-    if (p->state == PROMISE_UNRESOLVED) {
-        BUG("expected promise to have resolved");
-    }
-}
+// Function to assert that a promise has been resolved
+void promise_assert_finished(struct promise_t *p);
 
-void promise_resolve(struct promise_t *p, int status) {
-    if (p->state != PROMISE_UNRESOLVED) {
-        BUG("promise was already resolved");
-        return;
-    }
-    p->result.success_result = status;
-    p->state = PROMISE_SUCCESS;
-}
+// Function to resolve a promise with a success result
+void promise_resolve(struct promise_t *p, int status);
 
-void promise_reject(struct promise_t *p, int status, const char* fmt, ...) {
-    if (p->state != PROMISE_UNRESOLVED) {
-        BUG("promise was already resolved");
-        return;
-    }
-    p->result.failure_result.status = status;
+// Function to reject a promise with a failure result and an optional formatted error message
+void promise_reject(struct promise_t *p, int status, const char* fmt, ...);
 
-    va_list args;
-    va_start(args, fmt);
-    xsnprintf(p->result.failure_result.message, PROMISE_MESSAGE_LEN, fmt, args);
-    va_end(args);
+// Function to create a new promise
+struct promise_t *create_promise();
 
-    p->state = PROMISE_FAILURE;
-}
-
-struct promise_t *create_promise() {
-	// static int promise_id = 0; /* GLOBAL */
-
-	struct promise_t *new_promise = xmalloc(sizeof(struct promise_t));
-    new_promise->state = PROMISE_UNRESOLVED;
-
-    struct failure_result_t failure_result = {
-        .status = 0,
-        .message = { 0 }
-    };
-
-    new_promise->result.failure_result = failure_result;
-
-    return new_promise;
-}
-
-void release_promise(struct promise_t *promise) {
-    free(promise);
-}
+// Function to release the memory allocated for a promise
+void release_promise(struct promise_t *promise);
 
 #endif

--- a/promise.h
+++ b/promise.h
@@ -1,0 +1,85 @@
+#ifndef PROMISE_H
+#define PROMISE_H
+
+enum promise_state {
+	PROMISE_UNRESOLVED = 0,
+	PROMISE_SUCCESS = 1,
+	PROMISE_FAILURE = 2,
+};
+
+// struct PromiseTag {
+//     // int promise_id;
+//     void (*user_success_cbk)(int status, void* data);
+//     void (*user_error_cbk)(int status, char* msg, void* data); 
+// }
+
+typedef int success_result_t;
+
+#define PROMISE_MESSAGE_LEN 4096
+
+struct failure_result_t {
+    int status;
+    char message[PROMISE_MESSAGE_LEN];
+};
+
+struct promise_t {
+    enum promise_state state;
+    union {
+        success_result_t success_result;
+        struct failure_result_t failure_result;
+    } result;
+    // void (*success_cbk)(int status, void* data);
+    // void (*error_cbk)(int status, char* msg, void* data);
+};
+
+void promise_assert_finished(struct promise_t *p) {
+    if (p->state == PROMISE_UNRESOLVED) {
+        BUG("expected promise to have resolved");
+    }
+}
+
+void promise_resolve(struct promise_t *p, int status) {
+    if (p->state != PROMISE_UNRESOLVED) {
+        BUG("promise was already resolved");
+        return;
+    }
+    p->result.success_result = status;
+    p->state = PROMISE_SUCCESS;
+}
+
+void promise_reject(struct promise_t *p, int status, char* fmt, ...) {
+    if (p->state != PROMISE_UNRESOLVED) {
+        BUG("promise was already resolved");
+        return;
+    }
+    p->result.failure_result.status = status;
+
+    va_list args;
+    va_start(args, fmt);
+    xsnprintf(p->result.failure_result.message, PROMISE_MESSAGE_LEN, fmt, args);
+    va_end(args);
+
+    p->state = PROMISE_FAILURE;
+}
+
+struct promise_t *create_promise() {
+	// static int promise_id = 0; /* GLOBAL */
+
+	struct promise_t *new_promise = xmalloc(sizeof(struct promise_t));
+    new_promise->state = PROMISE_UNRESOLVED;
+
+    struct failure_result_t failure_result = {
+        .status = 0,
+        .message = { 0 }
+    };
+
+    new_promise->result.failure_result = failure_result;
+
+    return new_promise;
+}
+
+void release_promise(struct promise_t *promise) {
+    free(promise);
+}
+
+#endif

--- a/promise.h
+++ b/promise.h
@@ -2,6 +2,7 @@
 #define PROMISE_H
 
 #include "git-compat-util.h"
+#include "strbuf.h"
 
 enum promise_state {
 	PROMISE_UNRESOLVED = 0,
@@ -15,7 +16,7 @@ typedef int success_result_t;
 
 struct failure_result_t {
     int status;
-    strbuf *message;
+    struct strbuf message;
 };
 
 struct promise_t {
@@ -38,8 +39,8 @@ void promise_reject(struct promise_t *p, int status, const char* fmt, ...);
 // Function to create a new promise
 struct promise_t *promise_init();
 
-// Partially deallocates the promise
-int promise_consume(struct promise_t *promise, char **error_message);
+// Copies the error out of a failed promise
+void promise_copy_error(struct promise_t *promise, char **error_message, size_t *size);
 
 // Fully deallocates the promise
 void promise_release(struct promise_t *promise);

--- a/promise.h
+++ b/promise.h
@@ -15,7 +15,7 @@ typedef int success_result_t;
 
 struct failure_result_t {
     int status;
-    char message[PROMISE_MESSAGE_LEN];
+    strbuf *message;
 };
 
 struct promise_t {
@@ -36,9 +36,12 @@ void promise_resolve(struct promise_t *p, int status);
 void promise_reject(struct promise_t *p, int status, const char* fmt, ...);
 
 // Function to create a new promise
-struct promise_t *create_promise();
+struct promise_t *promise_init();
 
-// Function to release the memory allocated for a promise
-void release_promise(struct promise_t *promise);
+// Partially deallocates the promise
+int promise_consume(struct promise_t *promise, char **error_message);
+
+// Fully deallocates the promise
+void promise_release(struct promise_t *promise);
 
 #endif

--- a/t/t4108-apply-threeway.sh
+++ b/t/t4108-apply-threeway.sh
@@ -1,7 +1,5 @@
 #!/bin/sh
 
-export PATH="/Users/ironmagma/Code/git:$PATH"
-
 test_description='git apply --3way'
 
 GIT_TEST_DEFAULT_INITIAL_BRANCH_NAME=main

--- a/t/t4108-apply-threeway.sh
+++ b/t/t4108-apply-threeway.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+export PATH="/Users/ironmagma/Code/git:$PATH"
+
 test_description='git apply --3way'
 
 GIT_TEST_DEFAULT_INITIAL_BRANCH_NAME=main


### PR DESCRIPTION
This PR shows how we could use a Promise structure to help return values from functions.

## Problems

We seek to make libification easier by establishing a pattern for tracking whether a function errored in a rich way. Currently, any given function could immediately `die()`, or use `error()` to print directly to the console, bypassing any necessary verbosity checks. The use of `die()` makes use of Git as a library inconvenient since it is not graceful.

Additionally, returning using `return error(...)` (as is commonly done) always just returns a generic error value, `-1`, which provides little information.

## Approach

We will solve this problem by splitting the single return value into two return values: error, and message. However, managing two output variables can require some coordination, and this coordination can be abstracted away by use of a promise.

## Promise Concept

A promise is a contract representing "some task" that will eventually complete. Initially a promise is considered in a `pending` state. When it completes, one of two functions will eventually be called: reject, or resolve. Once resolved or rejected, the promise enters a different state representing the result.

Reject or resolve may only be called once on a given promise. So far, everything described is consistent with other implementations, notably the [ECMAScript standard for promises](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise).

However, this implementation departs from the complexity of those promises. In this implementation, promises are simple and canNOT be chained using `.then(...)` and do NOT have any notion of automatic bubbling (via re-entering the pending state).

## Current state of this PR

There is some demonstration of the use of Promise. However, I want to have a more nontrivial example, of where a function deep in the execution path failed, and we can display those error messages in a nested way such as (fake example):

```
Failed to apply patch.
     Could not apply hunk #3
Caused by:
     Missing binary patch data for 'foo.patch'
```

Finding a (compelling) path that is possible to reproduce this easily is where this PR is stalled.